### PR TITLE
Imporve Error group

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -210,7 +210,7 @@ call <sid>hi('Underlined', s:cdNone, {}, 'underline', {})
 
 call <sid>hi('Ignore', s:cdFront, {}, 'none', {})
 
-call <sid>hi('Error', s:cdNone, s:cdNone, 'undercurl', s:cdRed)
+call <sid>hi('Error', s:cdRed, {}, 'undercurl', s:cdRed)
 
 call <sid>hi('Todo', s:cdNone, s:cdLeftMid, 'none', {})
 


### PR DESCRIPTION
`Error` is used by many plugins to indicate errors, the current Error groups is just white which makes it hard to see when an error is reported for example. So I just changed this & used red instead & also removed the underline.

I hope these changes are fine with you & thanks for the colorscheme :+1: