### PR TITLE
Highlight special (doc) comments like regular comments

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -203,7 +203,7 @@ call <sid>hi('Special', s:cdFront, {}, 'none', {})
 call <sid>hi('SpecialChar', s:cdFront, {}, 'none', {})
 call <sid>hi('Tag', s:cdFront, {}, 'none', {})
 call <sid>hi('Delimiter', s:cdFront, {}, 'none', {})
-call <sid>hi('SpecialComment', s:cdFront, {}, 'none', {})
+call <sid>hi('SpecialComment', s:cdGreen, {}, 'none', {})
 call <sid>hi('Debug', s:cdFront, {}, 'none', {})
 
 call <sid>hi('Underlined', s:cdNone, {}, 'underline', {})


### PR DESCRIPTION
Previously, special / doc comments were rendered in foreground color,
i.e. white or light gray.  This makes it hard to recognize them as comments.
This commit colors them the same way as regular comments.