### PR TITLE
improved tex & python w/ vim-python/python-syntax

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -113,7 +113,7 @@ let s:cdBlue = {'gui': '#569CD6', 'cterm': s:cterm0D, 'cterm256': '75'}
 let s:cdDarkBlue = {'gui': '#223E55', 'cterm': s:cterm0D, 'cterm256': '73'}
 let s:cdLightBlue = {'gui': '#9CDCFE', 'cterm': s:cterm0C, 'cterm256': '117'}
 if g:codedark_conservative | let s:cdLightBlue = s:cdFront | endif
-let s:cdGreen = {'gui': '#6A9955', 'cterm': s:cterm0B, 'cterm256': '65'}
+let s:cdGreen = {'gui': '#608B4E', 'cterm': s:cterm0B, 'cterm256': '65'}
 let s:cdBlueGreen = {'gui': '#4EC9B0', 'cterm': s:cterm0F, 'cterm256': '43'}
 let s:cdLightGreen = {'gui': '#B5CEA8', 'cterm': s:cterm09, 'cterm256': '151'}
 let s:cdRed = {'gui': '#F44747', 'cterm': s:cterm08, 'cterm256': '203'}
@@ -191,7 +191,7 @@ call <sid>hi('Operator', s:cdFront, {}, 'none', {})
 call <sid>hi('Keyword', s:cdPink, {}, 'none', {})
 call <sid>hi('Exception', s:cdPink, {}, 'none', {})
 
-call <sid>hi('PreProc', s:cdBlue, {}, 'none', {})
+call <sid>hi('PreProc', s:cdPink, {}, 'none', {})
 call <sid>hi('Include', s:cdPink, {}, 'none', {})
 call <sid>hi('Define', s:cdPink, {}, 'none', {})
 call <sid>hi('Macro', s:cdPink, {}, 'none', {})
@@ -283,19 +283,17 @@ call <sid>hi('goMethodCall', s:cdYellow, {}, 'none', {})
 call <sid>hi('goSingleDecl', s:cdLightBlue, {}, 'none', {})
 
 " Python:
-if exists('g:python_highlight_builtin_funcs_kwarg')
-	call <sid>hi('pythonStatement', s:cdBlue, {}, 'none', {})
-	call <sid>hi('pythonOperator', s:cdBlue, {}, 'none', {})
-	call <sid>hi('pythonException', s:cdPink, {}, 'none', {})
-	call <sid>hi('pythonExClass', s:cdBlueGreen, {}, 'none', {})
-	call <sid>hi('pythonBuiltinObj', s:cdLightBlue, {}, 'none', {})
-	call <sid>hi('pythonBuiltinType', s:cdBlueGreen, {}, 'none', {})
-	call <sid>hi('pythonBoolean', s:cdBlue, {}, 'none', {})
-	call <sid>hi('pythonNone', s:cdBlue, {}, 'none', {})
-	call <sid>hi('pythonTodo', s:cdBlue, {}, 'none', {})
-	call <sid>hi('pythonClassVar', s:cdBlue, {}, 'none', {})
-	call <sid>hi('pythonClassDef', s:cdBlueGreen, {}, 'none', {})
-endif
+call <sid>hi('pythonStatement', s:cdBlue, {}, 'none', {})
+call <sid>hi('pythonOperator', s:cdBlue, {}, 'none', {})
+call <sid>hi('pythonException', s:cdPink, {}, 'none', {})
+call <sid>hi('pythonExClass', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('pythonBuiltinObj', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('pythonBuiltinType', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('pythonBoolean', s:cdBlue, {}, 'none', {})
+call <sid>hi('pythonNone', s:cdBlue, {}, 'none', {})
+call <sid>hi('pythonTodo', s:cdBlue, {}, 'none', {})
+call <sid>hi('pythonClassVar', s:cdBlue, {}, 'none', {})
+call <sid>hi('pythonClassDef', s:cdBlueGreen, {}, 'none', {})
 
 " TeX:
 call <sid>hi('texStatement', s:cdBlue, {}, 'none', {})

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -113,7 +113,7 @@ let s:cdBlue = {'gui': '#569CD6', 'cterm': s:cterm0D, 'cterm256': '75'}
 let s:cdDarkBlue = {'gui': '#223E55', 'cterm': s:cterm0D, 'cterm256': '73'}
 let s:cdLightBlue = {'gui': '#9CDCFE', 'cterm': s:cterm0C, 'cterm256': '117'}
 if g:codedark_conservative | let s:cdLightBlue = s:cdFront | endif
-let s:cdGreen = {'gui': '#608B4E', 'cterm': s:cterm0B, 'cterm256': '65'}
+let s:cdGreen = {'gui': '#6A9955', 'cterm': s:cterm0B, 'cterm256': '65'}
 let s:cdBlueGreen = {'gui': '#4EC9B0', 'cterm': s:cterm0F, 'cterm256': '43'}
 let s:cdLightGreen = {'gui': '#B5CEA8', 'cterm': s:cterm09, 'cterm256': '151'}
 let s:cdRed = {'gui': '#F44747', 'cterm': s:cterm08, 'cterm256': '203'}
@@ -189,10 +189,9 @@ call <sid>hi('Repeat', s:cdPink, {}, 'none', {})
 call <sid>hi('Label', s:cdPink, {}, 'none', {})
 call <sid>hi('Operator', s:cdFront, {}, 'none', {})
 call <sid>hi('Keyword', s:cdPink, {}, 'none', {})
-call <sid>hi('pythonOperator', s:cdPink, {}, 'none', {})
 call <sid>hi('Exception', s:cdPink, {}, 'none', {})
 
-call <sid>hi('PreProc', s:cdPink, {}, 'none', {})
+call <sid>hi('PreProc', s:cdBlue, {}, 'none', {})
 call <sid>hi('Include', s:cdPink, {}, 'none', {})
 call <sid>hi('Define', s:cdPink, {}, 'none', {})
 call <sid>hi('Macro', s:cdPink, {}, 'none', {})
@@ -282,3 +281,28 @@ call <sid>hi('goReceiverType', s:cdDarkBlue, {}, 'none', {})
 call <sid>hi('goFunctionCall', s:cdYellow, {}, 'none', {})
 call <sid>hi('goMethodCall', s:cdYellow, {}, 'none', {})
 call <sid>hi('goSingleDecl', s:cdLightBlue, {}, 'none', {})
+
+" Python:
+if exists('g:python_highlight_builtin_funcs_kwarg')
+	call <sid>hi('pythonStatement', s:cdBlue, {}, 'none', {})
+	call <sid>hi('pythonOperator', s:cdBlue, {}, 'none', {})
+	call <sid>hi('pythonException', s:cdPink, {}, 'none', {})
+	call <sid>hi('pythonExClass', s:cdBlueGreen, {}, 'none', {})
+	call <sid>hi('pythonBuiltinObj', s:cdLightBlue, {}, 'none', {})
+	call <sid>hi('pythonBuiltinType', s:cdBlueGreen, {}, 'none', {})
+	call <sid>hi('pythonBoolean', s:cdBlue, {}, 'none', {})
+	call <sid>hi('pythonNone', s:cdBlue, {}, 'none', {})
+	call <sid>hi('pythonTodo', s:cdBlue, {}, 'none', {})
+	call <sid>hi('pythonClassVar', s:cdBlue, {}, 'none', {})
+	call <sid>hi('pythonClassDef', s:cdBlueGreen, {}, 'none', {})
+endif
+
+" TeX:
+call <sid>hi('texStatement', s:cdBlue, {}, 'none', {})
+call <sid>hi('texBeginEnd', s:cdYellow, {}, 'none', {})
+call <sid>hi('texBeginEndName', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('texOption', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('texBeginEndModifier', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('texDocType', s:cdPink, {}, 'none', {})
+call <sid>hi('texDocTypeArgs', s:cdLightBlue, {}, 'none', {})
+


### PR DESCRIPTION
I tried to solve the question "Why does file syntax not look exactly like in Visual Studio Code?" for python and latex. The python part needs the vim plugin python-syntax.