### PR TITLE
fixed a few gaps with the colors of some javascript types

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -252,6 +252,9 @@ call <sid>hi('jsVariableDef', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsFuncArgs', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsRegexpString', s:cdLightRed, {}, 'none', {})
 call <sid>hi('jsThis', s:cdBlue, {}, 'none', {})
+call <sid>hi('jsDestructuringBlock', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('jsObjectKey', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('jsGlobalObjects', s:cdBlueGreen, {}, 'none', {})
 
 " Ruby:
 call <sid>hi('rubyClassNameTag', s:cdBlueGreen, {}, 'none', {})


### PR DESCRIPTION
Specifically:

1. jsDestructuringBlock -> light blue
1. jsObjectKey -> light blue
1. jsGlobalObjects -> blue-green