### PR TITLE
fixed the class and module name highlighting in Ruby

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -255,6 +255,9 @@ call <sid>hi('jsThis', s:cdBlue, {}, 'none', {})
 
 " Ruby:
 call <sid>hi('rubyClassNameTag', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('rubyClassName', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('rubyModuleName', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('rubyConstant', s:cdBlueGreen, {}, 'none', {})
 
 " Golang:
 call <sid>hi('goPackage', s:cdBlue, {}, 'none', {})


### PR DESCRIPTION
Hi, thank you so much for your work here. It looks really good. I had a tiny issue with the highlighting of ruby files. The Class names and Module names were not getting the "BlueGreen" which is the correct color:

![image](https://user-images.githubusercontent.com/12149734/50530929-1d8b8100-0b03-11e9-8c5c-3d207094d076.png)

I fixed this locally with the change in this PR and thought perhaps others could also benefit from this: 

![image](https://user-images.githubusercontent.com/12149734/50530959-70653880-0b03-11e9-86a4-53e656f6a49c.png)
![image](https://user-images.githubusercontent.com/12149734/50531098-5f1d2b80-0b05-11e9-9178-11df87a680b9.png)


Not sure if OS matters here, but just in case, I had this issue on MacOS. 