### PR TITLE
highlighting for XML and JSX to fix open/close tags

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -256,6 +256,11 @@ call <sid>hi('jsDestructuringBlock', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsObjectKey', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsGlobalObjects', s:cdBlueGreen, {}, 'none', {})
 
+" XML:
+call <sid>hi('xmlTag', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('xmlTagName', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('xmlEndTag', s:cdBlueGreen, {}, 'none', {})
+
 " Ruby:
 call <sid>hi('rubyClassNameTag', s:cdBlueGreen, {}, 'none', {})
 call <sid>hi('rubyClassName', s:cdBlueGreen, {}, 'none', {})


### PR DESCRIPTION
This fixes issue #21.
The reason for this is the default XML syntax which has different colors on start and end tags.
This PR sets the open and close tags color to "BlueGreen" which is what VS code uses.

Before: 
![image](https://user-images.githubusercontent.com/12149734/50542779-5be97480-0bc5-11e9-9c08-5eae3e52eda0.png)

After:
![image](https://user-images.githubusercontent.com/12149734/50542745-f6958380-0bc4-11e9-83bf-27d54e30bbd7.png)

