### PR TITLE
Javascript syntax improvements

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -262,6 +262,7 @@ call <sid>hi('jsThis', s:cdBlue, {}, 'none', {})
 call <sid>hi('jsDestructuringBlock', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsObjectKey', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsGlobalObjects', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('jsModuleKeyword', s:cdLightBlue, {}, 'none', {})
 
 " Ruby:
 call <sid>hi('rubyClassNameTag', s:cdBlueGreen, {}, 'none', {})

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -269,6 +269,7 @@ call <sid>hi('jsExtendsKeyword', s:cdBlue, {}, 'none', {})
 call <sid>hi('jsExportDefault', s:cdPink, {}, 'none', {})
 call <sid>hi('jsFuncCall', s:cdYellow, {}, 'none', {})
 call <sid>hi('jsObjectKey', s:cdYellow, {}, 'none', {})
+call <sid>hi('jsObjectValue', s:cdLightBlue, {}, 'none', {})
 
 " Ruby:
 call <sid>hi('rubyClassNameTag', s:cdBlueGreen, {}, 'none', {})

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -264,6 +264,9 @@ call <sid>hi('jsObjectKey', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsGlobalObjects', s:cdBlueGreen, {}, 'none', {})
 call <sid>hi('jsModuleKeyword', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsClassDefinition', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('jsClassKeyword', s:cdBlue, {}, 'none', {})
+call <sid>hi('jsExtendsKeyword', s:cdBlue, {}, 'none', {})
+call <sid>hi('jsExportDefault', s:cdPink, {}, 'none', {})
 call <sid>hi('jsFuncCall', s:cdYellow, {}, 'none', {})
 
 " Ruby:

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -263,6 +263,7 @@ call <sid>hi('jsDestructuringBlock', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsObjectKey', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsGlobalObjects', s:cdBlueGreen, {}, 'none', {})
 call <sid>hi('jsModuleKeyword', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('jsClassDefinition', s:cdBlueGreen, {}, 'none', {})
 
 " Ruby:
 call <sid>hi('rubyClassNameTag', s:cdBlueGreen, {}, 'none', {})

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -268,6 +268,7 @@ call <sid>hi('jsClassKeyword', s:cdBlue, {}, 'none', {})
 call <sid>hi('jsExtendsKeyword', s:cdBlue, {}, 'none', {})
 call <sid>hi('jsExportDefault', s:cdPink, {}, 'none', {})
 call <sid>hi('jsFuncCall', s:cdYellow, {}, 'none', {})
+call <sid>hi('jsObjectKey', s:cdYellow, {}, 'none', {})
 
 " Ruby:
 call <sid>hi('rubyClassNameTag', s:cdBlueGreen, {}, 'none', {})

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -270,6 +270,7 @@ call <sid>hi('jsExportDefault', s:cdPink, {}, 'none', {})
 call <sid>hi('jsFuncCall', s:cdYellow, {}, 'none', {})
 call <sid>hi('jsObjectKey', s:cdYellow, {}, 'none', {})
 call <sid>hi('jsObjectValue', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('jsParen', s:cdLightBlue, {}, 'none', {})
 
 " Ruby:
 call <sid>hi('rubyClassNameTag', s:cdBlueGreen, {}, 'none', {})

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -264,6 +264,7 @@ call <sid>hi('jsObjectKey', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsGlobalObjects', s:cdBlueGreen, {}, 'none', {})
 call <sid>hi('jsModuleKeyword', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsClassDefinition', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('jsFuncCall', s:cdYellow, {}, 'none', {})
 
 " Ruby:
 call <sid>hi('rubyClassNameTag', s:cdBlueGreen, {}, 'none', {})


### PR DESCRIPTION
Here are some improvements to bring the JS highlighting closer to VS code:

**Module Keyword:**
Before:
<img width="396" alt="image" src="https://user-images.githubusercontent.com/12149734/50725823-5976a580-1104-11e9-97f8-0f75dbde1c96.png">
VS code:
<img width="452" alt="image" src="https://user-images.githubusercontent.com/12149734/50725826-64313a80-1104-11e9-9704-b84963a2c0e1.png">
Change from this PR:
<img width="404" alt="image" src="https://user-images.githubusercontent.com/12149734/50725837-9478d900-1104-11e9-8799-55adbf3cbfd7.png">

**Class Definition:**
Before:
<img width="337" alt="image" src="https://user-images.githubusercontent.com/12149734/50725855-e02b8280-1104-11e9-8d51-0f846ee5141c.png">
VS code:
<img width="373" alt="image" src="https://user-images.githubusercontent.com/12149734/50725857-ed487180-1104-11e9-962e-13a5f2e4311d.png">
Change from this PR:
<img width="349" alt="image" src="https://user-images.githubusercontent.com/12149734/50725917-e8d08880-1105-11e9-8f5c-5dd735c8d61f.png">

**Function Call:**
Before:
<img width="301" alt="image" src="https://user-images.githubusercontent.com/12149734/50725984-b70bf180-1106-11e9-8d47-c210ffa17243.png">
VS code:
<img width="297" alt="image" src="https://user-images.githubusercontent.com/12149734/50725986-c0955980-1106-11e9-9cfc-fd50dbe7c1c6.png">
Change from this PR:
<img width="291" alt="image" src="https://user-images.githubusercontent.com/12149734/50725999-fb978d00-1106-11e9-99bd-cd9537174f77.png">

**Object Key and value:**
Before:
<img width="275" alt="image" src="https://user-images.githubusercontent.com/12149734/50726028-72348a80-1107-11e9-8bce-1a5762c75936.png">
VS code:
<img width="253" alt="image" src="https://user-images.githubusercontent.com/12149734/50726030-7e204c80-1107-11e9-96bc-5fba20e29e78.png">
Change from this PR:
<img width="248" alt="image" src="https://user-images.githubusercontent.com/12149734/50726058-d3f4f480-1107-11e9-9e54-f77e44a7e935.png">

**JS parentheses:**
Before: 
![image](https://user-images.githubusercontent.com/12149734/50726267-fdfbe600-110a-11e9-90eb-bee4a17706b9.png)
VS code:
![image](https://user-images.githubusercontent.com/12149734/50726271-07854e00-110b-11e9-9b06-462317ed20ea.png)
Change from this PR:
![image](https://user-images.githubusercontent.com/12149734/50726276-179d2d80-110b-11e9-9662-65ee457f2e01.png)
