### PR TITLE
Better Markdown Support

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -220,6 +220,17 @@ call <sid>hi('Error', s:cdRed, s:cdBack, 'undercurl', s:cdRed)
 
 call <sid>hi('Todo', s:cdNone, s:cdLeftMid, 'none', {})
 
+" Markdown:
+call <sid>hi('markdownBold', s:cdBlue, {}, 'bold', {})
+call <sid>hi('markdownCode', s:cdOrange, {}, 'none', {})
+call <sid>hi('markdownRule', s:cdBlue, {}, 'bold', {})
+call <sid>hi('markdownCodeDelimiter', s:cdOrange, {}, 'none', {})
+call <sid>hi('markdownHeadingDelimiter', s:cdBlue, {}, 'none', {})
+call <sid>hi('markdownFootnote', s:cdOrange, {}, 'none', {})
+call <sid>hi('markdownFootnoteDefinition', s:cdOrange, {}, 'none', {})
+call <sid>hi('markdownUrl', s:cdLightBlue, {}, 'underline', {})
+call <sid>hi('markdownLinkText', s:cdOrange, {}, 'none', {})
+
 " JSON:
 call <sid>hi('jsonKeyword', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsonEscape', s:cdYellowOrange, {}, 'none', {})

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -230,6 +230,7 @@ call <sid>hi('markdownFootnote', s:cdOrange, {}, 'none', {})
 call <sid>hi('markdownFootnoteDefinition', s:cdOrange, {}, 'none', {})
 call <sid>hi('markdownUrl', s:cdLightBlue, {}, 'underline', {})
 call <sid>hi('markdownLinkText', s:cdOrange, {}, 'none', {})
+call <sid>hi('markdownEscape', s:cdYellowOrange, {}, 'none', {})
 
 " JSON:
 call <sid>hi('jsonKeyword', s:cdLightBlue, {}, 'none', {})


### PR DESCRIPTION
Added better support for Markdown as per issue #16 

Before:
![image](https://user-images.githubusercontent.com/17597548/50728491-e3fcdc00-10e7-11e9-86e0-efc877d9175b.png)

After:
![image](https://user-images.githubusercontent.com/17597548/50728481-ab5d0280-10e7-11e9-9604-fd002c385f21.png)
