### PR TITLE
tweak Search color to make Quickfix legible

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -98,8 +98,8 @@ let s:cdDiffRedLightLight = {'gui': '#FB0101', 'cterm': s:cterm08, 'cterm256': '
 let s:cdDiffGreenDark = {'gui': '#373D29', 'cterm': s:cterm0B, 'cterm256': '237'}
 let s:cdDiffGreenLight = {'gui': '#4B5632', 'cterm': s:cterm09, 'cterm256': '58'}
 
-let s:cdSearchCurrent = {'gui': '#49545F', 'cterm': s:cterm09, 'cterm256': '239'}
-let s:cdSearch = {'gui': '#4C4E50', 'cterm': s:cterm0A, 'cterm256': '239'}
+let s:cdSearchCurrent = {'gui': '#49545F', 'cterm': s:cterm09, 'cterm256': '236'}
+let s:cdSearch = {'gui': '#4C4E50', 'cterm': s:cterm0A, 'cterm256': '236'}
 
 " Syntax colors:
 


### PR DESCRIPTION
I love your theme, but Quickfix highlighting was not legible, at least in Golang.  
before:
![before](https://user-images.githubusercontent.com/1626079/50804270-3c380780-12bb-11e9-8fed-e24db2e5c1b1.png)
And after:
![screenshot 2019-01-07 at 8 20 51 pm](https://user-images.githubusercontent.com/1626079/50804330-74d7e100-12bb-11e9-823a-0cdde361b62f.png)
This was just changing 239 -> 236. 237 also works, slightly less legible but a greater highlight contrast.
Such a slight tweak, but it save my sanity! Hope it can do same for others.
