### PR TITLE
Support Spell Checking Highlighting

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -219,6 +219,11 @@ call <sid>hi('Error', s:cdRed, s:cdBack, 'undercurl', s:cdRed)
 
 call <sid>hi('Todo', s:cdNone, s:cdLeftMid, 'none', {})
 
+call <sid>hi('SpellBad', s:cdRed, s:cdBack, 'undercurl', s:cdRed)
+call <sid>hi('SpellCap', s:cdRed, s:cdBack, 'undercurl', s:cdRed)
+call <sid>hi('SpellRare', s:cdRed, s:cdBack, 'undercurl', s:cdRed)
+call <sid>hi('SpellLocal', s:cdRed, s:cdBack, 'undercurl', s:cdRed)
+
 " Markdown:
 call <sid>hi('markdownBold', s:cdBlue, {}, 'bold', {})
 call <sid>hi('markdownCode', s:cdOrange, {}, 'none', {})


### PR DESCRIPTION
I love codedark, but I make so many spelling mistakes that don't get picked up because they don't get highlighted. This PR just creates bindings for the spelling highlight groups and uses the same settings as the error highlight group.

Note that Vim is very good at distinguishing between code and text that actually needs to be spell checked. Also If you are wondering why my github is empty it's because I packed my bags for gitlab, check me out [here](https://gitlab.com/morgaux)!