### PR TITLE
Add Blue accent to YAML keys and constants

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -430,3 +430,6 @@ call <sid>hi('luaFuncArgName', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('luaFuncKeyword', s:cdPink, {}, 'none', {})
 call <sid>hi('luaLocal', s:cdPink, {}, 'none', {})
 call <sid>hi('luaBuiltIn', s:cdBlue, {}, 'none', {})
+" YAML:
+call <sid>hi('yamlKey', s:cdBlue, {}, 'none', {})
+call <sid>hi('yamlConstant', s:cdBlue, {}, 'none', {})


### PR DESCRIPTION
Dark blue for yaml/ansible is more faithful to original VSCode color scheme
Also added keyword highlight for YAML Constants (Blue like on VSCode)

before:

![Screenshot from 2020-03-29 21-42-09](https://user-images.githubusercontent.com/598882/77858826-31da9400-7206-11ea-985b-0bc9d77c30c1.png)

after:

![Screenshot from 2020-03-29 21-42-15](https://user-images.githubusercontent.com/598882/77858829-34d58480-7206-11ea-8c55-36ba8d74565c.png)

