### PR TITLE
Make search results visible

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -98,8 +98,8 @@ let s:cdDiffRedLightLight = {'gui': '#FB0101', 'cterm': s:cterm08, 'cterm256': '
 let s:cdDiffGreenDark = {'gui': '#373D29', 'cterm': s:cterm0B, 'cterm256': '237'}
 let s:cdDiffGreenLight = {'gui': '#4B5632', 'cterm': s:cterm09, 'cterm256': '58'}
 
-let s:cdSearchCurrent = {'gui': '#49545F', 'cterm': s:cterm09, 'cterm256': '236'}
-let s:cdSearch = {'gui': '#4C4E50', 'cterm': s:cterm0A, 'cterm256': '236'}
+let s:cdSearchCurrent = {'gui': '#4B5632', 'cterm': s:cterm09, 'cterm256': '58'} 
+let s:cdSearch = {'gui': '#264F78', 'cterm': s:cterm03, 'cterm256': '24'}
 
 " Syntax colors:
 


### PR DESCRIPTION
As raised in https://github.com/tomasiser/vim-code-dark/issues/61, I modified the color scheme so that search results are now more visible.

It will look like this
<img width="170" alt="vim_search" src="https://user-images.githubusercontent.com/10479549/89093622-04972180-d371-11ea-9f44-8df96c4ca89c.png">
as opposed to before, which is barely visible
<img width="170" alt="vim_search_before" src="https://user-images.githubusercontent.com/10479549/89094083-475af880-d375-11ea-98ba-b5770375f881.png">
