### PR TITLE
- added support for vim default syntax highlighting of Asciidoc

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -238,6 +238,29 @@ call <sid>hi('markdownUrl', s:cdLightBlue, {}, 'underline', {})
 call <sid>hi('markdownLinkText', s:cdOrange, {}, 'none', {})
 call <sid>hi('markdownEscape', s:cdYellowOrange, {}, 'none', {})
 
+" Asciidoc (for default syntax highlighting)
+call <sid>hi("asciidocAttributeEntry", s:cdYellowOrange, {}, 'none', {})
+call <sid>hi("asciidocAttributeList", s:cdPink, {}, 'none', {})
+call <sid>hi("asciidocAttributeRef", s:cdYellowOrange, {}, 'none', {})
+call <sid>hi("asciidocHLabel", s:cdBlue, {}, 'bold', {})
+call <sid>hi("asciidocListingBlock", s:cdOrange, {}, 'none', {})
+call <sid>hi("asciidocMacroAttributes", s:cdYellowOrange, {}, 'none', {})
+call <sid>hi("asciidocOneLineTitle", s:cdBlue, {}, 'bold', {})
+call <sid>hi("asciidocPassthroughBlock", s:cdBlue, {}, 'none', {})
+call <sid>hi("asciidocQuotedMonospaced", s:cdOrange, {}, 'none', {})
+call <sid>hi("asciidocTriplePlusPassthrough", s:cdYellow, {}, 'none', {})
+call <sid>hi("asciidocMacro", s:cdPink, {}, 'none', {})
+call <sid>hi("asciidocAdmonition", s:cdOrange, {}, 'none', {})
+call <sid>hi("asciidocQuotedEmphasized", s:cdBlue, {}, 'italic', {})
+call <sid>hi("asciidocQuotedEmphasized2", s:cdBlue, {}, 'italic', {})
+call <sid>hi("asciidocQuotedEmphasizedItalic", s:cdBlue, {}, 'italic', {})
+hi! link asciidocBackslash Keyword
+hi! link asciidocQuotedBold markdownBold
+hi! link asciidocQuotedMonospaced2 asciidocQuotedMonospaced
+hi! link asciidocQuotedUnconstrainedBold asciidocQuotedBold
+hi! link asciidocQuotedUnconstrainedEmphasized asciidocQuotedEmphasized
+hi! link asciidocURL markdownUrl
+
 " JSON:
 call <sid>hi('jsonKeyword', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsonEscape', s:cdYellowOrange, {}, 'none', {})


### PR DESCRIPTION
Asciidoc did not highlight with this theme. As I love vim-code-dark I added support for Asciidoc based on the syntax file coming with vim. I tried to match the look of Markdown to achieve a consistent experience. It looks good for me. However, I did not check all highlighting options. There might be rough edges.

vim's syntax file for Asciidoc is not very good. It does not work reliably. This affects every theme including this one. I will have a look at vim-asciidoc. If there are changes needed for vim-asciidoc as well, I will create a separate pull request.