### PR TITLE
feat(highlight): Not change background in Normal and LineNr mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# this is fork of `tomasiser/vim-code-dark`
+It plays nicely with tmux active/inactive panes by prohibiting the theme to set background colour. This results in useing tmux-defined background, which, in turn, enables easier visual distinction between active and inactive panes. See screenshots below.
+
+![Screenshot 2021-05-24 at 12 44 32](https://user-images.githubusercontent.com/9802715/119336802-5e653100-bc8e-11eb-8821-e42db0228d0e.png)
+![Screenshot 2021-05-24 at 12 44 09](https://user-images.githubusercontent.com/9802715/119336808-602ef480-bc8e-11eb-8a0c-a89d7db8aefe.png)
+
+
 # vim-code-dark
 `vim-code-dark` is a dark **color scheme for [Vim](http://www.vim.org/)** heavily inspired by the look of the Dark+ scheme of [Visual Studio Code](https://code.visualstudio.com/). While many of the colors are same, there are additional colors for specific usage or reserved for future use. The scheme also defines specific GUI colors (e.g. popup menu) and fully supports [`vim-airline`](https://github.com/vim-airline/vim-airline).
 

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -21,7 +21,12 @@ fun! <sid>hi(group, fg, bg, attr, sp)
     exec "hi " . a:group . " guifg=" . a:fg.gui . " ctermfg=" . (g:codedark_term256 ? a:fg.cterm256 : a:fg.cterm)
   endif
   if !empty(a:bg)
-    exec "hi " . a:group . " guibg=" . a:bg.gui . " ctermbg=" . (g:codedark_term256 ? a:bg.cterm256 : a:bg.cterm)
+    " Not changing background color in Normal and LineNr modes allows to use tmux background and thus
+    " handle background change when losing focus - ideal for moving between panes.
+    " Inspiration from https://stackoverflow.com/a/33553372/700659
+    if a:group != "Normal" && a:group != "LineNr"
+      exec "hi " . a:group . " guibg=" . a:bg.gui . " ctermbg=" . (g:codedark_term256 ? a:bg.cterm256 : a:bg.cterm)
+    endif
   endif
   if a:attr != ""
     exec "hi " . a:group . " gui=" . a:attr . " cterm=" . a:attr

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -24,7 +24,7 @@ fun! <sid>hi(group, fg, bg, attr, sp)
     " Not changing background color in Normal and LineNr modes allows to use tmux background and thus
     " handle background change when losing focus - ideal for moving between panes.
     " Inspiration from https://stackoverflow.com/a/33553372/700659
-    if a:group != "Normal" && a:group != "LineNr"
+    if a:group != "Normal" && a:group != "LineNr" && a:group != "EndOfBuffer"
       exec "hi " . a:group . " guibg=" . a:bg.gui . " ctermbg=" . (g:codedark_term256 ? a:bg.cterm256 : a:bg.cterm)
     endif
   endif


### PR DESCRIPTION
Not changing background color in Normal and LineNr modes allows to use tmux background and thus handle background change when losing focus - ideal for moving between panes. Inspiration from https://stackoverflow.com/a/33553372/700659

See below how this enables visual distinction when tmux pane is active (first) and inactive (second)

![Screenshot 2021-05-24 at 12 44 32](https://user-images.githubusercontent.com/9802715/119336329-d4b56380-bc8d-11eb-839c-28e2a2f153bd.png)
![Screenshot 2021-05-24 at 12 44 09](https://user-images.githubusercontent.com/9802715/119336336-d717bd80-bc8d-11eb-86f2-fd893b8c97e2.png)
