### PR TITLE
Add support for JSDoc annotations

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -388,6 +388,13 @@ call <sid>hi('jsIfElseBlock', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsParenIfElse', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsSpreadOperator', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('jsSpreadExpression', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('jsDocParam', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('jsDocSeeTags', s:cdBlue, {}, 'none', {})
+call <sid>hi('jsDocTags', s:cdBlue, {}, 'none', {})
+call <sid>hi('jsDocType', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('jsDocTypeBrackets', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('jsDocTypeNoParam', s:cdBlueGreen, {}, 'none', {})
+call <sid>hi('jsDocTypeRecord', s:cdBlueGreen, {}, 'none', {})
 
 " Typescript:
 call <sid>hi('typescriptLabel', s:cdLightBlue, {}, 'none', {})


### PR DESCRIPTION
This makes JSDoc annotations look much similar to VS Code.

Before:

![image](https://user-images.githubusercontent.com/7288/131446622-6755cf96-cd99-4d12-8b66-d300bcc72d4e.png)


After:

![image](https://user-images.githubusercontent.com/7288/131446549-cd9a7012-4a81-4ceb-b95b-e0478d598260.png)
