### PR TITLE
Add basic italics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ set renderoptions=type:directx,gamma:1.5,contrast:0.5,geom:1,renmode:5,taamode:1
 ```
 
 ### Are italics supported? 
-Italics in comments can be enabled by setting `g:codedark_italics = 1` before
-setting the colorscheme. Please note that your terminal must support rendering italic fonts.
+Italics in comments can be enabled by setting `g:codedark_italics = 1` _before_
+setting the colorscheme in your `.vimrc` like so:
+```
+let g:codedark_italics = 1
+colorscheme codedark
+```
+Please note that your terminal must support rendering italic fonts.
 

--- a/README.md
+++ b/README.md
@@ -140,3 +140,7 @@ set guifont=Powerline_Consolas:h11
 set renderoptions=type:directx,gamma:1.5,contrast:0.5,geom:1,renmode:5,taamode:1,level:0.5
 ```
 
+### Are italics supported? 
+Italics in comments can be enabled by setting `g:codedark_italics = 1` before
+setting the colorscheme. Please note that your terminal must support rendering italic fonts.
+

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -107,6 +107,11 @@ if !exists("g:codedark_conservative")
     let g:codedark_conservative=0
 endif
 
+" Italicized comments
+if !exists("g:codedark_italics")
+    let g:codedark_italics=0
+endif
+
 let s:cdGray = {'gui': '#808080', 'cterm': s:cterm04, 'cterm256': '08'}
 let s:cdViolet = {'gui': '#646695', 'cterm': s:cterm04, 'cterm256': '60'}
 let s:cdBlue = {'gui': '#569CD6', 'cterm': s:cterm0D, 'cterm256': '75'}
@@ -174,7 +179,7 @@ hi! link diffAdded DiffAdd
 hi! link diffChanged DiffChange
 hi! link diffRemoved DiffDelete
 
-call <sid>hi('Comment', s:cdGreen, {}, 'none', {})
+if g:codedark_italics | call <sid>hi('Comment', s:cdGreen, {}, 'italic', {}) | else | call <sid>hi('Comment', s:cdGreen, {}, 'none', {}) | endif
 
 call <sid>hi('Constant', s:cdBlue, {}, 'none', {})
 call <sid>hi('String', s:cdOrange, {}, 'none', {})
@@ -209,7 +214,7 @@ call <sid>hi('Special', s:cdYellowOrange, {}, 'none', {})
 call <sid>hi('SpecialChar', s:cdFront, {}, 'none', {})
 call <sid>hi('Tag', s:cdFront, {}, 'none', {})
 call <sid>hi('Delimiter', s:cdFront, {}, 'none', {})
-call <sid>hi('SpecialComment', s:cdGreen, {}, 'none', {})
+if g:codedark_italics | call <sid>hi('SpecialComment', s:cdGreen, {}, 'italic', {}) | else | call <sid>hi('SpecialComment', s:cdGreen, {}, 'none', {}) | endif
 call <sid>hi('Debug', s:cdFront, {}, 'none', {})
 
 call <sid>hi('Underlined', s:cdNone, {}, 'underline', {})


### PR DESCRIPTION
Attached screenshots of the colorscheme rendered in Konsole after enabling italics.
![Captura de pantalla de 2021-09-14 10-40-31](https://user-images.githubusercontent.com/49008964/133289510-8f37b9f9-2069-451b-a15b-8258df308d35.png)

