### PR TITLE
Use color code 231 for the airline term256 white

### DIFF
--- a/autoload/airline/themes/codedark.vim
+++ b/autoload/airline/themes/codedark.vim
@@ -38,7 +38,7 @@ elseif !exists("g:codedark_term256")
     let g:codedark_term256=0
 endif
 
-let s:cdFront = {'gui': '#FFFFFF', 'cterm':  (g:codedark_term256 ? '15' : s:cterm07)}
+let s:cdFront = {'gui': '#FFFFFF', 'cterm':  (g:codedark_term256 ? '231' : s:cterm07)}
 let s:cdFrontGray = {'gui': '#D4D4D4', 'cterm': (g:codedark_term256 ? '188' : s:cterm05)}
 let s:cdBack = {'gui': '#1E1E1E', 'cterm': (g:codedark_term256 ? '234' : s:cterm00)}
 let s:cdSelection = {'gui': '#264F78', 'cterm': (g:codedark_term256 ? '24' : s:cterm01)}


### PR DESCRIPTION
15 is the system's base0F color, which may not be white if the user has installed a color theme for their terminal. 231 is the xterm-256color code for #ffffff and is more portable than 15; see provided image for current behavior.

Current behavior if the user has a terminal color scheme:
![image](https://user-images.githubusercontent.com/11011773/138516396-db605fee-7366-4c25-94c3-b496b8996614.png)

Patched behavior with the same color scheme: 
![image](https://user-images.githubusercontent.com/11011773/138516621-4eb93cd2-2d96-458d-89c2-bf7ae9c49009.png)
