### PR TITLE
Some general fixes

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -223,7 +223,7 @@ call <sid>hi('Debug', s:cdFront, {}, 'none', {})
 call <sid>hi('Underlined', s:cdNone, {}, 'underline', {})
 call <sid>hi("Conceal", s:cdFront, s:cdBack, 'none', {})
 
-call <sid>hi('Ignore', s:cdFront, {}, 'none', {})
+call <sid>hi('Ignore', s:cdBack, {}, 'none', {})
 
 call <sid>hi('Error', s:cdRed, s:cdBack, 'undercurl', s:cdRed)
 

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -293,6 +293,12 @@ call <sid>hi('TSTag', s:cdBlue, {}, 'none', {})
 call <sid>hi('TSTagDelimiter', s:cdGray, {}, 'none', {})
 
 " Markdown:
+call <sid>hi('markdownH1', s:cdBlue, {}, 'bold', {})
+call <sid>hi('markdownH2', s:cdBlue, {}, 'bold', {})
+call <sid>hi('markdownH3', s:cdBlue, {}, 'bold', {})
+call <sid>hi('markdownH4', s:cdBlue, {}, 'bold', {})
+call <sid>hi('markdownH5', s:cdBlue, {}, 'bold', {})
+call <sid>hi('markdownH6', s:cdBlue, {}, 'bold', {})
 call <sid>hi('markdownBold', s:cdBlue, {}, 'bold', {})
 call <sid>hi('markdownCode', s:cdOrange, {}, 'none', {})
 call <sid>hi('markdownRule', s:cdBlue, {}, 'bold', {})


### PR DESCRIPTION
This PR has two commits that fixes some problems.

### Make Ignore highlight group invisible

The `Ignore` group is supposed to hide stuff. For example, [vim-dotoo](https://github.com/dhruvasagar/vim-dotoo) (an orgmode plugin), via the option `let g:dotoo_headline_shade_leading_stars = 1`, it should hide the leading stars to the org mode's heading. With this commit, I simply made the `fg` of the `Ignore` highlight group the same as the foreground.

*before*
![Screenshot 2022-07-01 at 16 14 16](https://user-images.githubusercontent.com/96259932/176913578-90cec586-dfd4-49b1-9fdb-5d4b3b392e41.png)

*after*
![Screenshot 2022-07-01 at 16 14 38](https://user-images.githubusercontent.com/96259932/176914491-1f7b13e3-9462-4fae-a683-f73ee8bf345d.png)

### Make markdown headings same color as VSCode

*in vscode*
<img width="273" alt="Screenshot 2022-07-01 at 16 10 02" src="https://user-images.githubusercontent.com/96259932/176914979-0cf04cc1-36ff-4cb6-be32-104b333e03aa.png">

*in vim before*
![Screenshot 2022-07-01 at 16 09 20](https://user-images.githubusercontent.com/96259932/176915022-75d75326-147b-4e5f-8626-672f4f00db7f.png)

*in vim after*
![Screenshot 2022-07-01 at 16 11 20](https://user-images.githubusercontent.com/96259932/176915053-fe17f61d-6ec9-49a1-ab27-aa9c4bee5c1f.png)




