### PR TITLE
Make typescript exceptions consistent

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -450,6 +450,7 @@ call <sid>hi('VueKey', s:cdPink, {}, 'none', {})
 
 " Typescript:
 call <sid>hi('typescriptLabel', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('typescriptTry', s:cdPink, {}, 'none', {})
 call <sid>hi('typescriptExceptions', s:cdPink, {}, 'none', {})
 call <sid>hi('typescriptBraces', s:cdFront, {}, 'none', {})
 call <sid>hi('typescriptEndColons', s:cdLightBlue, {}, 'none', {})

--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -450,7 +450,7 @@ call <sid>hi('VueKey', s:cdPink, {}, 'none', {})
 
 " Typescript:
 call <sid>hi('typescriptLabel', s:cdLightBlue, {}, 'none', {})
-call <sid>hi('typescriptExceptions', s:cdLightBlue, {}, 'none', {})
+call <sid>hi('typescriptExceptions', s:cdPink, {}, 'none', {})
 call <sid>hi('typescriptBraces', s:cdFront, {}, 'none', {})
 call <sid>hi('typescriptEndColons', s:cdLightBlue, {}, 'none', {})
 call <sid>hi('typescriptParens', s:cdFront, {}, 'none', {})


### PR DESCRIPTION
Pink typescript exceptions matches python and general exceptions and is also what is used in vscode. It also makes it stand out better from other code.

Before:
![image](https://github.com/tomasiser/vim-code-dark/assets/3172483/b33ed1f3-b65f-4f53-be88-cebffdfd3d53)

After:
![image](https://github.com/tomasiser/vim-code-dark/assets/3172483/2dc6b6e6-3a86-429a-ab49-659089c0d5b4)

VS Code for reference:
![image](https://github.com/tomasiser/vim-code-dark/assets/3172483/adef53bc-8844-432a-8e89-aa2919a9802f)



