### PR TITLE
Update color for InlayHints

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -654,3 +654,4 @@ call <sid>hi('LspCxxHlSymNamespace', s:cdSilver, {}, 'none', {})
 " Coc Explorer:
 call <sid>hi('CocHighlightText', {}, s:cdSelection, 'none', {})
 call <sid>hi('CocExplorerIndentLine', s:cdCursorDark, {}, 'none', {})
+call <sid>hi('CocInlayHint', s:cdLineNumber, {}, 'none', {})


### PR DESCRIPTION
Use the same color used for non-important text. This style appears when CoC InlayHints (hints for typing and arguments implicitly guessed by the LSP Server) are in place.

The default VSCode Dark+ theme uses the style shown in the second screenshot for InlayHints objects.

before:
![image](https://github.com/tomasiser/vim-code-dark/assets/102958/535b8307-d17e-40bd-aa3d-b607fc57222f)

after:
![image](https://github.com/tomasiser/vim-code-dark/assets/102958/2a2f0e53-b6bd-4a9c-b19d-d778d8df80a4)
